### PR TITLE
Changes for KSP 1.2.2

### DIFF
--- a/APIs/RTWrapper.cs
+++ b/APIs/RTWrapper.cs
@@ -120,7 +120,7 @@ namespace AY
 
             try
             {
-                actualRTsettings = RTSettingsType.GetField("mInstance", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+                actualRTsettings = RTSettingsType.GetProperty("get_Instance", BindingFlags.Public | BindingFlags.Static).GetValue(null, null);
             }
             catch (Exception)
             {

--- a/APIs/USILSWrapper.cs
+++ b/APIs/USILSWrapper.cs
@@ -54,7 +54,7 @@ namespace AY
             LogFormatted_DebugOnly("Attempting to Grab USI LS Types...");
 
             //find the USILS part module type
-            USIMLSType = getType("LifeSupport.ModuleLifeSupport"); 
+            USIMLSType = getType("LifeSupport.ModuleLifeSupportSystem"); 
 
             if (USIMLSType == null)
             {
@@ -93,9 +93,9 @@ namespace AY
             return null;
         }
 
-        public class ModuleLifeSupport
+        public class ModuleLifeSupportSystem
         {
-            internal ModuleLifeSupport(Object a)
+            internal ModuleLifeSupportSystem(Object a)
             {
                 actualModuleLifeSupport = a;
 

--- a/AYController.cs
+++ b/AYController.cs
@@ -607,19 +607,14 @@ namespace AY
                         if (!PartsToDelete.Contains(entry.Key))
                             PartsToDelete.Add(entry.Key);
                     }
-                    VslRstr.Clear(); //clear the vessel roster
+                    //VslRstr.Clear(); //clear the vessel roster
 
                     //Begin calcs
-                    if (Utilities.GameModeisFlight) // if in flight compile the vessel roster
+                    if (Utilities.GameModeisFlight && FlightGlobals.ActiveVessel != null) // if in flight compile the vessel roster
                     {
-                        //Work-around for stock bug in KSP 1.2
-                        if (FlightGlobals.ActiveVessel.crewedParts > 0 && FlightGlobals.ActiveVessel.GetVesselCrew().Count == 0)
-                        {
-                            FlightGlobals.ActiveVessel.RebuildCrewList();
-                        }
                         VslRstr = FlightGlobals.ActiveVessel.GetVesselCrew();
                     }
-
+                    
                     //loop through all parts in the parts list of the vessel
                     for (int i = 0; i < vesselparts.Count; i++)
                     {
@@ -1080,11 +1075,6 @@ namespace AY
             // otherwise we load the vessel settings
             Currentvesselid = newvessel.id;
             LoadVesselSettings(newvessel);
-            //Work-around for stock bug in KSP 1.2
-            if (newvessel.crewedParts > 0 && newvessel.GetVesselCrew().Count == 0)
-            {
-                newvessel.RebuildCrewList();
-            }
         }
 
         private void OnVesselChange(Vessel newvessel)

--- a/AYControllerGUI.cs
+++ b/AYControllerGUI.cs
@@ -716,6 +716,7 @@ namespace AY
                 if (_showCrew)
             {
                 GUILayout.Label("Crew", Textures.SectionTitleStyle);
+                //VslRstr = FlightGlobals.ActiveVessel.GetVesselCrew();
                 if (VslRstr.Count > 0)
                 {
                     for (int i = VslRstr.Count - 1; i >= 0; --i)

--- a/AYProcessPartModules.cs
+++ b/AYProcessPartModules.cs
@@ -103,7 +103,7 @@ namespace AY
         private KPBSWrapper.PlanetaryGreenhouse KPBSgh;
         private float currentRateConverter;
         private float currentRateGreenhouse;
-        private USILSWrapper.ModuleLifeSupport usiMLS;
+        private USILSWrapper.ModuleLifeSupportSystem usiMLS;
         private IONRCSWrapper.ModuleIONPoweredRCS tmpIonPoweredRcs;
         private IONRCSWrapper.ModulePPTPoweredRCS tmpPPTPoweredRcs;
         private float IONRCSelecUse;
@@ -748,7 +748,7 @@ namespace AY
             tmpPower = 0f;
             FillAmount = recipe.FillAmount;
             if (KPBS > 0) FillAmount = KPBS;
-            var efficiency = tmpRegRc.GetHeatThrottle()*tmpRegRc.Efficiency;
+            var efficiency = tmpRegRc.GetEfficiencyMultiplier();
 
             recInputs = tmpRegRc.Recipe.Inputs;
             for (int i = recInputs.Count - 1; i >= 0; --i)
@@ -1601,12 +1601,12 @@ namespace AY
                     ProcessModuleResourceConverter(currentPart.name, currentPart, psdpart, 0);
                     break;
 
-                case "ModuleLifeSupport":
+                /*case "ModuleLifeSupport":
                     prtName = currentPart.name;
                     prtPower = "";
                     prtActive = false;
                     tmpPower = 0;
-                    usiMLS = new USILSWrapper.ModuleLifeSupport(psdpart);
+                    usiMLS = new USILSWrapper.ModuleLifeSupportSystem(psdpart);
 
                     if ((Utilities.GameModeisFlight && currentPart.protoModuleCrew.Count > 0) || Utilities.GameModeisEditor)
                     {
@@ -1641,9 +1641,9 @@ namespace AY
 
                                 AYVesselPartLists.AddPart(currentPart.craftID, prtName, currentPart.partInfo.title, psdpart.moduleName, false, prtActive, tmpPower, true, false);
                             }
-                        }*/
+                        }
                     }
-                    break;
+                    break;*/
             }
         }
         

--- a/Distribution/GameData/REPOSoftTech/AmpYear/AmpYear.version
+++ b/Distribution/GameData/REPOSoftTech/AmpYear/AmpYear.version
@@ -2,8 +2,8 @@
 "NAME":"AmpYear",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=147",
 "DOWNLOAD":"https://spacedock.info/mod/144/AmpYear",
-"VERSION":{"MAJOR":1,"MINOR":4,"PATCH":3,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":1},
+"VERSION":{"MAJOR":1,"MINOR":4,"PATCH":4,"BUILD":0},
+"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2},
 "KSP_VERSION_MIN":{"MAJOR":1,"MINOR":2,"PATCH":0},
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":1}
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":2}
 }

--- a/Distribution/GameData/REPOSoftTech/AmpYear/ChangeLog.txt
+++ b/Distribution/GameData/REPOSoftTech/AmpYear/ChangeLog.txt
@@ -1,4 +1,11 @@
-﻿V1.4.3.0 "and More Fixes"
+﻿V1.4.4.0 "KSP1.2.2"
+	Changes for KSP 1.2.2
+	Changes for ResourceConverters.
+	Fixed issue with crew list not getting correct list. https://github.com/JPLRepo/AmpYear/issues/56
+	Fixed RemoteTech integration. https://github.com/JPLRepo/AmpYear/issues/54
+	Removed partial USI LS support. - USI LS has moved to VesselModule's (an internal KSP construct) which AmpYear does not support without major
+	rework. Sorry but seeing how I don't personally use it, and the work involved to update AmpYear to support this I have decided to removed partial support for it until such time as it can be fixed. https://github.com/JPLRepo/AmpYear/issues/55	
+V1.4.3.0 "and More Fixes"
 	Fix NFE interfaces.
 	Fix KAS interfaces.
 V1.4.2.0 "More Fixes"

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.4.3")]
+[assembly: AssemblyVersion("1.4.4")]
 [assembly: KSPAssembly("AmpYear", 1, 4)] 


### PR DESCRIPTION
Changes for KSP 1.2.2
	Changes for ResourceConverters.
	Fixed issue with crew list not getting correct list. https://github.com/JPLRepo/AmpYear/issues/56
	Fixed RemoteTech integration. https://github.com/JPLRepo/AmpYear/issues/54	
	Removed partial USI LS support. - USI LS has moved to VesselModule's (an internal KSP construct) which AmpYear does not support without major
	rework. Sorry but seeing how I don't personally use it, and the work involved to update AmpYear to support this I have decided to removed partial support for it until such time as it can be fixed. https://github.com/JPLRepo/AmpYear/issues/55	