### PR TITLE
Converters

### DIFF
--- a/AYProcessPartModules.cs
+++ b/AYProcessPartModules.cs
@@ -1065,7 +1065,7 @@ namespace AY
                 {
                     Utilities.Log("Wrong USI LS version - disabled.");
                     Utilities.Log("Error message: {0}", ex.Message);
-                    KPBSPresent = false;
+                    USILSPresent = false;                    
                 }
             if (KERBALISMPresent)
                 try

--- a/Distribution/GameData/REPOSoftTech/AmpYear/AmpYear.version
+++ b/Distribution/GameData/REPOSoftTech/AmpYear/AmpYear.version
@@ -2,7 +2,7 @@
 "NAME":"AmpYear",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=147",
 "DOWNLOAD":"https://spacedock.info/mod/144/AmpYear",
-"VERSION":{"MAJOR":1,"MINOR":4,"PATCH":9,"BUILD":0},
+"VERSION":{"MAJOR":1,"MINOR":5,"PATCH":0,"BUILD":0},
 "KSP_VERSION":{"MAJOR":1,"MINOR":3,"PATCH":0},
 "KSP_VERSION_MIN":{"MAJOR":1,"MINOR":3,"PATCH":0},
 "KSP_VERSION_MAX":{"MAJOR":1,"MINOR":3,"PATCH":0}

--- a/Distribution/GameData/REPOSoftTech/AmpYear/ChangeLog.txt
+++ b/Distribution/GameData/REPOSoftTech/AmpYear/ChangeLog.txt
@@ -1,4 +1,7 @@
-﻿V1.4.9.0 "Bugs"
+﻿V1.5.0.0 "Converters"
+	Fix bug with detecting the correct status for Resource Converters.
+	Fix log spam for unsupported USI LS version installed. Now you will get only one log message and then AmpYear will stop processing USI LS parts.
+V1.4.9.0 "Bugs"
 	Fixed log spam in editor. (SPH/VAB)
 	Fixed Dark Side calcs.
 	Added support for DSEV mod.

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.4.9")]
-[assembly: KSPAssembly("AmpYear", 1, 4)] 
+[assembly: AssemblyVersion("1.5.0")]
+[assembly: KSPAssembly("AmpYear", 1, 5)] 


### PR DESCRIPTION
Fix bug with detecting the correct status for Resource Converters.   
Fix log spam for unsupported USI LS version installed. Now you will get only one log message and then AmpYear will stop processing USI LS parts.   