### PR TITLE
Updating AYProcessPartModules.cs for USI/MKS 1.1

### DIFF
--- a/AYProcessPartModules.cs
+++ b/AYProcessPartModules.cs
@@ -1684,12 +1684,16 @@ namespace AY
                                 {
                                     case "ModuleLifeSupportRecycler":
                                     case "ModuleHabitation":
+                                    case "ModuleLifeSupportExtender":
                                     case "USILS_LifeSupportExtenderSwapOption":
+                                    case "ModuleResourceConverter_USI":
                                     case "USI_Converter":
                                     case "ModuleEfficiencyPart":
+                                    case "ModuleBulkConverter":
                                     case "MKS_BulkConverterSwapOption":
                                         ProcessModuleResourceConverter(currentPart.name, currentPart, converter, 0, bayname);
                                         break;
+                                    case "ModuleRessourceHarvester_USI":
                                     case "USI_Harvester":
                                         ProcessModuleResourceharvester(currentPart.name, currentPart, converter);
                                         break;
@@ -1706,12 +1710,16 @@ namespace AY
                     break;
                 case "ModuleLifeSupportRecycler":
                 case "ModuleHabitation":
+                case "ModuleLifeSupportExtender":
                 case "USILS_LifeSupportExtenderSwapOption":
+                case "ModuleResourceConverter_USI":
                 case "USI_Converter":
                 case "ModuleEfficiencyPart":
+                case "ModuleBulkConverter":
                 case "MKS_BulkConverterSwapOption":
                     ProcessModuleResourceConverter(currentPart.name, currentPart, psdpart, 0);
                     break;
+                case "ModuleRessourceHarvester_USI":
                 case "USI_Harvester":
                     ProcessModuleResourceharvester(currentPart.name, currentPart, psdpart);
                     break;

--- a/AYProcessPartModules.cs
+++ b/AYProcessPartModules.cs
@@ -1684,13 +1684,13 @@ namespace AY
                                 {
                                     case "ModuleLifeSupportRecycler":
                                     case "ModuleHabitation":
-                                    case "ModuleLifeSupportExtender":
-                                    case "ModuleResourceConverter_USI":
+                                    case "USILS_LifeSupportExtenderSwapOption":
+                                    case "USI_Converter":
                                     case "ModuleEfficiencyPart":
-                                    case "ModuleBulkConverter":
+                                    case "MKS_BulkConverterSwapOption":
                                         ProcessModuleResourceConverter(currentPart.name, currentPart, converter, 0, bayname);
                                         break;
-                                    case "ModuleRessourceHarvester_USI":
+                                    case "USI_Harvester":
                                         ProcessModuleResourceharvester(currentPart.name, currentPart, converter);
                                         break;
                                     case "ModuleHeatPump":
@@ -1706,13 +1706,13 @@ namespace AY
                     break;
                 case "ModuleLifeSupportRecycler":
                 case "ModuleHabitation":
-                case "ModuleLifeSupportExtender":
-                case "ModuleResourceConverter_USI":
+                case "USILS_LifeSupportExtenderSwapOption":
+                case "USI_Converter":
                 case "ModuleEfficiencyPart":
-                case "ModuleBulkConverter":
+                case "MKS_BulkConverterSwapOption":
                     ProcessModuleResourceConverter(currentPart.name, currentPart, psdpart, 0);
                     break;
-                case "ModuleRessourceHarvester_USI":
+                case "USI_Harvester":
                     ProcessModuleResourceharvester(currentPart.name, currentPart, psdpart);
                     break;
                 case "ModuleHeatPump":


### PR DESCRIPTION
MKS Module names were changes from previous versions for at least harvesters, converters, bulk converters, and life support extenders. Heat pumps are the same in MKS 1.1. Not sure about "ModuleLifeSupport"